### PR TITLE
Fix linking errors on Mac

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,15 @@ rustzx-clippy = "clippy --workspace --all-features"
 rustzx-run = "run --release --bin rustzx --"
 rustzx-install = "install --path rustzx"
 rustzx-build-assets = "run -p rustzx-test --bin build-assets"
+
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/rustzx-core/src/zx/machine/mod.rs
+++ b/rustzx-core/src/zx/machine/mod.rs
@@ -70,7 +70,7 @@ impl ZXMachine {
         if clocks_trough_line >= specs.clocks_screen_row {
             return 0;
         }
-        return self.specs().contention_pattern[(clocks_trough_line % 8) as usize];
+        return self.specs().contention_pattern[clocks_trough_line % 8];
     }
 
     /// Checks port contention on machine

--- a/rustzx-core/src/zx/tape/mod.rs
+++ b/rustzx-core/src/zx/tape/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 
 use enum_dispatch::enum_dispatch;
 
+#[allow(clippy::large_enum_variant)]
 #[enum_dispatch(TapeImpl)]
 pub enum ZXTape<A: LoadableAsset + SeekableAsset> {
     Tap(Tap<A>),

--- a/rustzx-core/src/zx/video/border.rs
+++ b/rustzx-core/src/zx/video/border.rs
@@ -69,7 +69,7 @@ impl<FB: FrameBuffer> ZXBorder<FB> {
         // begining of the first line (first pixel timing minus border lines
         // minus left border columns)
         let clocks_origin = specs.clocks_first_pixel
-            - 8 * BORDER_ROWS * specs.clocks_line as usize
+            - 8 * BORDER_ROWS * specs.clocks_line
             - BORDER_COLS * CLOCKS_PER_COL
             + specs.clocks_ula_beam_shift;
         // return first pixel pos
@@ -78,9 +78,9 @@ impl<FB: FrameBuffer> ZXBorder<FB> {
         }
         // get clocks relative to first pixel
         let clocks = clocks - clocks_origin;
-        let mut line = clocks / specs.clocks_line as usize;
+        let mut line = clocks / specs.clocks_line;
         // so, next pixel will be current + 2
-        let mut pixel = ((clocks % specs.clocks_line as usize) + 1) * PIXELS_PER_CLOCK as usize;
+        let mut pixel = ((clocks % specs.clocks_line) + 1) * PIXELS_PER_CLOCK;
         // if beam out of screen on horizontal pos.
         // pixel - 2 bacause we added 2 on prev line
         if pixel - PIXELS_PER_CLOCK >= SCREEN_WIDTH {

--- a/rustzx-test/src/bin/build-assets.rs
+++ b/rustzx-test/src/bin/build-assets.rs
@@ -83,10 +83,10 @@ impl DockerContainer {
         let mut cmd = Command::new("docker");
         cmd.arg("run");
         if let Some(name) = self.name {
-            cmd.args(&["--name", &name]);
+            cmd.args(["--name", &name]);
         }
         for mount_point in self.mount_points {
-            cmd.args(&[
+            cmd.args([
                 "-v",
                 &format!("{}:{}", mount_point.dir.display(), mount_point.mount.0),
             ]);
@@ -101,7 +101,7 @@ impl DockerContainer {
         if let Some(action) = self.action {
             match action {
                 DockerAction::ShellScript { path } => {
-                    cmd.args(&["sh", &path.0]);
+                    cmd.args(["sh", &path.0]);
                 }
             }
         }

--- a/rustzx-test/src/framework.rs
+++ b/rustzx-test/src/framework.rs
@@ -504,7 +504,7 @@ impl Fingerprintable for Vec<u8> {
         use sha2::{Digest, Sha256};
 
         let mut hasher = Sha256::default();
-        hasher.update(&self);
+        hasher.update(self);
         let hash = hasher.finalize();
         base64::encode(hash)
     }


### PR DESCRIPTION
These lines in the cargo toml fix the "undefined architecture" link errors that seem to crop up on m1 Mac when building.