### PR TITLE
BlocksCount.lines = CANVAS_HEIGHT after last pixel

### DIFF
--- a/rustzx-core/src/zx/video/screen.rs
+++ b/rustzx-core/src/zx/video/screen.rs
@@ -51,7 +51,7 @@ impl BlocksCount {
                 columns = 0;
             };
             if lines >= CANVAS_HEIGHT {
-                lines = 0;
+                lines = CANVAS_HEIGHT;
                 columns = 0;
             }
         };


### PR DESCRIPTION
Previously BlocksCount was set to { lines: 0, columns: 0 } whenever the raster was to the right of the last pixel, or in the bottom border.

This made the calculations of how many pixels left to render wrong under some circumstances, making the emulator miss pixel updates.

As a proof of concept, try this patch:

```diff
diff --git a/rustzx-core/src/zx/controller.rs b/rustzx-core/src/zx/controller.rs
index fd9c3fe..9c51c5e 100644
--- a/rustzx-core/src/zx/controller.rs
+++ b/rustzx-core/src/zx/controller.rs
@@ -463,8 +463,8 @@ impl<H: Host> Z80Bus for ZXController<H> {
             let pos = self.frame_pos();
             self.mixer.process(pos);
         }
-        self.screen.process_clocks(self.frame_clocks);
         if self.frame_clocks >= self.machine.specs().clocks_frame {
+            self.screen.process_clocks(self.frame_clocks);
             self.new_frame();
             self.passed_frames += 1;
         }
```

This patch makes the screen only update once per frame. (Could be a useful optimization for any software that doesn't need raster-perfect simulation.)

Note that with this change, the `process_clocks` function doesn't think it needs to update any pixels at all, which is wrong, as it actually should update *all* of them.

I think the same bug may also make the emulator miss updates that occur in the very last pixels of the frame.

This pull request fixes those problems by setting
`BlocksCount { lines: CANVAS_HEIGHT, columns: 0 }` whenever the raster is after the last displayed pixel, which makes sure `process_clocks` know how many pixels it should update.